### PR TITLE
Fix bug in file tree where folders immediate collapsed after opening

### DIFF
--- a/src/client/app/plugins/prototypebuilder/RemoteFileBrowser.js
+++ b/src/client/app/plugins/prototypebuilder/RemoteFileBrowser.js
@@ -106,7 +106,7 @@ define(function (require, exports, module) {
                 }
             }).catch(function (err) {
                 console.log(err);
-            });              
+            });
         }
 
         if (code === 39) {
@@ -120,8 +120,8 @@ define(function (require, exports, module) {
             e.preventDefault();
             window.location.hash = '#file-browser';
         }
-    } 
-    
+    }
+
     /**
         Constructs a new instance of the RemoteFileBrowser
         @param {function} filterFunc a function to filter which file should be shown in the browser if null, then all files are shown
@@ -135,7 +135,7 @@ define(function (require, exports, module) {
 
     RemoteFileBrowser.prototype._treeList = null;
     RemoteFileBrowser.prototype._baseDirectory = null;
-    
+
     /**
      * Utility function to sort the list of files returned by the remote file browser
      * @param   {String}   a first argument
@@ -159,7 +159,7 @@ define(function (require, exports, module) {
             });
         });
     }
-    
+
     function readExamplesFolder() {
         var ws = WSManager.getWebSocket();
         return new Promise(function (resolve, reject) {
@@ -257,9 +257,9 @@ define(function (require, exports, module) {
                                 rfb.emuchartsManager.preview("#svg-preview");
                                 d3.select("#file-preview").style("display", "block");
                             }
-                        });                    
+                        });
                     }
-                    
+
                     if (data.isDirectory) {
                         d3.select("#file-browser").style("width", "100%");
                         d3.select("#file-preview").style("display", "none");
@@ -267,8 +267,10 @@ define(function (require, exports, module) {
                         d3.select("#file-browser").style("width", "400px");
                         d3.select("#file-preview").style("width", "230px").style("display", "block");
                     }
-                    
-                    if (data.isDirectory && !data.children && !data._children) {
+                }).addListener("ItemExpanded", function (event) {
+                    var data = event.data;
+
+                    if (data.isDirectory && !data.children && !data._children && !data.empty && !data._empty) {
                         getRemoteDirectory(data.path)
                             .then(function (files) {
                                 data.children = files || [];

--- a/src/client/app/plugins/prototypebuilder/TreeList.js
+++ b/src/client/app/plugins/prototypebuilder/TreeList.js
@@ -107,6 +107,12 @@ define(function (require, exports, module) {
         var self = this,
             el = this.el;
         function toggleChildren(d) {
+            // Trigger expand event if we have no children shown and we're not empty, or we're empty and collapsed
+            if ((!d.children & !d.empty) || d._empty) {
+                var event = {type: "ItemExpanded", data: d};
+                self.fire(event);
+            }
+
             if (d.children) {
                 d._children = d.children;
                 d.children = null;
@@ -121,6 +127,21 @@ define(function (require, exports, module) {
                 d.empty = d._empty;
                 d._empty = null;
             }
+        }
+
+        // Updates expander chevrons based on whether the folder's children are visible
+        function updateChevrons(chevrons) {
+            chevrons.attr("class", function (d) {
+                var icon = d.children || d.empty ? " glyphicon-chevron-down"
+                    : d._children ? "glyphicon-chevron-right"
+                    : d.isDirectory ? " glyphicon-chevron-right"
+                    : "";
+                return "chevron glyphicon " + icon;
+            }).style("height", function (d) {
+                return d.isDirectory ? "90%" : "0%";
+            }).style("padding", function (d) {
+                return d.isDirectory ? "6px 0px 6px 0px" : "0px";
+            });
         }
 
         var tree = d3.layout.treelist().childIndent(childIndent).nodeHeight(listHeight);
@@ -171,33 +192,11 @@ define(function (require, exports, module) {
 
         var listWrap = enteredNodes.append("div").classed("line", true);
         var updatedNodes = nodeEls, exitedNodes = nodeEls.exit();
-        var chevron = listWrap.append("span").attr("class", function (d) {
-            var icon = d.children || d.empty ? " glyphicon-chevron-down"
-                : d._children ? "glyphicon-chevron-right"
-                : d.isDirectory ? " glyphicon-chevron-right"
-                : "";
-            return "chevron glyphicon " + icon;
-        }).style("height", function (d) {
-            return d.isDirectory ? "90%" : "0%";
-        }).style("padding", function (d) {
-            return d.isDirectory ? "6px 0px 6px 0px" : "0px";
-        });
+        var chevron = listWrap.append("span");
+        updateChevrons(chevron);
         chevron.on("click", function (d) {
             toggleChildren(d);
             self.render(d);
-            if (self._selectedData !== d) {
-                var pd = self._selectedData;
-                self._selectedData = d;
-                ul.selectAll("li.node").classed("selected", function (d) {
-                    return self._selectedData === d;
-                });
-                d.previousData = pd;
-                var event = {type: "SelectedItemChanged", data: d};
-                // clear all editable flags
-                ul.selectAll("li.node").select(".label").attr("contentEditable", false);
-                console.log(event);
-                self.fire(event);
-            }
         });
 
 
@@ -212,17 +211,7 @@ define(function (require, exports, module) {
             .html(function (d) { return d.name; });
 
         //update chevron direction and style
-        nodeEls.select("span.chevron").attr("class", function (d) {
-            var icon = d.children || d.empty ? " glyphicon-chevron-down"
-                : d._children ? "glyphicon-chevron-right"
-                : d.isDirectory ? " glyphicon-chevron-right"
-                : "";
-            return "chevron glyphicon " + icon;
-        }).style("height", function (d) {
-            return d.isDirectory ? "90%" : "0%";
-        }).style("padding", function (d) {
-            return d.isDirectory ? "6px 0px 6px 0px" : "0px";
-        });
+        updateChevrons(nodeEls.select("span.chevron"));
         //update list class
         nodeEls.attr("class", function (d, i) {
             var c = i % 2 === 0 ? "node even" : "node odd";


### PR DESCRIPTION
Fixes #220 

This fix adds a separate "ItemExpanded" event that loads the folder's
children, rather than it being done when the item is selected for the
first time. This also makes the behaviour more consistent - previously
the first single-click on a folder would expand it, but subsequent
clicks would not. Now clicking the expander arrow or double clicking
expands/collapses, while single clicks on the item only ever select it.

Also combined some related repeated code into a function.

I've tested this fix both with and without network delay (since that affected the initial issue)